### PR TITLE
creates vue.config.js to compute publicPath

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  publicPath: process.env.NODE_ENV === 'production'
+    ? '/eleform/'
+    : '/'
+}


### PR DESCRIPTION
in production this should now populate with the corresponding GitHub Pages URL subdirectory, so that the assets will load at martindelille.github.io/eleform/

fixes #21